### PR TITLE
Update README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,33 @@
-
-
 Run `%load_ext graph_notebook.magics` at the top of a notebook to enable gremlin magic like `%%gremlin`
 
 Default password is `admin`.
 
 ## Example Runs
+
+```sh
+docker run --network="host" -p 8888:8888 -t graph-notebook
+
+# Sharing directories
+docker run --network="host" -p 8889:8889 -p 8888:8888 -v $(pwd)/out:/working 
+
+
+# For connecting with IAM Auth
+docker run -p 8888:8888 \
+ -e AWS_ACCESS_KEY_ID \
+ -e AWS_SECRET_ACCESS_KEY \ 
+ -e AWS_SESSION_TOKEN \ 
+ -e AWS_REGION="us-east-1" \
+ graph-notebook
+```
+
+## [Host Networking Mode (--network="host")](url=https://docs.docker.com/network/host/)
+
+Host mode networking can be useful to optimize performance, and in situations where a container needs to handle a large range of ports, as it does not require network address translation (NAT), and no “userland-proxy” is created for each port.
+
+The host networking driver only works on **Linux hosts**, and is **not supported on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server**.
+
+## Example Local Mac/Windows Runs
+
 ```sh
 docker run -p 8888:8888 -t graph-notebook
 
@@ -24,7 +47,8 @@ Example Notebooks are placed in the `Example Notebooks` sub-directory
 
 Within the Jupyter Notebook you must configure the Notebook settings to account for `localhost` or `remote` connections.
 
-### Example Localhost Connection:
+### Example Localhost Connection
+
 ```ipynb
 %%graph_notebook_config
     {
@@ -40,7 +64,8 @@ Within the Jupyter Notebook you must configure the Notebook settings to account 
     }
 ```
 
-### Example Neptune Proxy Connection:
+### Example Neptune Proxy Connection
+
 ```ipynb
     {
         "host": "clustername.cluster-ididididid.us-east-1.neptune.amazonaws.com",
@@ -53,8 +78,6 @@ Within the Jupyter Notebook you must configure the Notebook settings to account 
         "load_from_s3_arn": ""
     }
 ```
-
-
 
 ## Configurable Properties
 
@@ -77,7 +100,3 @@ Within the Jupyter Notebook you must configure the Notebook settings to account 
 | PROVIDE_EXAMPLES   | Whether or not to automatically copy example notebooks over when a volume is being shared.        |
 | GRAPH_NOTEBOOK_PROXY_HOST   | Host that will proxy requests to Neptune. Will not proxy if not provided.        |
 | GRAPH_NOTEBOOK_PROXY_PORT   | Port for proxy host.        |
-
-
-
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,10 +6,10 @@ Default password is `admin`.
 
 ## Example Runs
 ```sh
-docker run --network="host"  -p 8888:8888 -t graph-notebook
+docker run -p 8888:8888 -t graph-notebook
 
 # Sharing directories
-docker run --network="host"  -p 8889:8889 -p 8888:8888 -v $(pwd)/out:/working 
+docker run -p 8889:8889 -p 8888:8888 -v $(pwd)/out:/working 
 
 # For connecting with IAM Auth
 docker run -p 8888:8888 \


### PR DESCRIPTION
Issue #, if available: [#491](https://github.com/aws/graph-notebook/issues/491)
Description of changes:

**Update to README.md**
This PR removes the `--network="host"` option from the script to fix an issue where published ports are discarded when using host network mode. The `--network="host"` option is used to run a container in the host network mode, which allows the container to use the host's network stack and IP address. However, this option also causes published ports to be discarded, which can prevent the container from being accessible from outside the host.

Removing the `--network="host"` option from the script will run the container in the default bridge network mode, allowing published ports to be accessible from outside the host. This fix ensures that the container can be accessed from other machines on the network and resolves the issue of published ports being discarded.

This PR is a simple and effective solution to the issue and has been tested to ensure that it works as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.